### PR TITLE
Pipe no longer clobbers `_`, fixes #181

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1,4 +1,4 @@
-var Node, Negatable, Block, Atom, Literal, Var, Key, Index, Chain, Call, List, Obj, Prop, Arr, Unary, Binary, Assign, Import, Of, Existence, Fun, Class, Super, Parens, Splat, Jump, Throw, Return, While, For, Try, Switch, Case, If, Label, Cascade, JS, Util, Vars, DECLS, ref$, UTILS, LEVEL_TOP, LEVEL_PAREN, LEVEL_LIST, LEVEL_COND, LEVEL_OP, LEVEL_CALL, PREC, TAB, ID, SIMPLENUM, slice$ = [].slice, replace$ = ''.replace;
+var Node, Negatable, Block, Atom, Literal, Var, Key, Index, Chain, Call, List, Obj, Prop, Arr, Unary, Binary, Assign, Import, Of, Existence, Fun, Class, Super, Parens, Splat, Jump, Throw, Return, While, For, Try, Switch, Case, If, Label, Pipe, Cascade, JS, Util, Vars, DECLS, ref$, UTILS, LEVEL_TOP, LEVEL_PAREN, LEVEL_LIST, LEVEL_COND, LEVEL_OP, LEVEL_CALL, PREC, TAB, ID, SIMPLENUM, slice$ = [].slice, replace$ = ''.replace;
 (Node = function(){
   throw Error('unimplemented');
 }).prototype = {
@@ -295,10 +295,6 @@ exports.Block = Block = (function(superclass){
     (ref$ = this.lines).splice.apply(ref$, [this.neck(), 0].concat(slice$.call(arguments)));
     return this;
   };
-  prototype.pipe = function(it){
-    this.lines.push(Assign(Var('_'), this.lines.pop()), it);
-    return this;
-  };
   prototype.unwrap = function(){
     if (this.lines.length === 1) {
       return this.lines[0];
@@ -544,6 +540,9 @@ exports.Var = Var = (function(superclass){
   };
   prototype.varName = prototype.show;
   prototype.compile = function(o){
+    if (o.pipee != null && this.value === '_') {
+      this.value = o.pipee;
+    }
     if (this.temp) {
       return o.scope.free(this.value);
     } else {
@@ -917,7 +916,7 @@ exports.Chain = Chain = (function(superclass){
     }
   };
   prototype.expandSlice = function(o, assign){
-    var tails, i, tail, ref$, _;
+    var tails, i, tail, ref$, _$;
     tails = this.tails;
     i = -1;
     while (tail = tails[++i]) {
@@ -925,9 +924,8 @@ exports.Chain = Chain = (function(superclass){
         if (tails[i + 1] instanceof Call) {
           tail.carp('calling a slice');
         }
-        _ = tails.splice(0, i + 1);
-        _ = _.pop().key.toSlice(o, Chain(this.head, _).unwrap(), tail.symbol, assign);
-        this.head = (_.front = this.front, _);
+        _$ = (_$ = tails.splice(0, i + 1), _$.pop().key.toSlice(o, Chain(this.head, _$).unwrap(), tail.symbol, assign));
+this.head = (_$.front = this.front, _$);
         i = -1;
       }
     }
@@ -1390,7 +1388,7 @@ exports.Unary = Unary = (function(superclass){
     }[it] + 'crement';
   }
   prototype.compileNode = function(o){
-    var that, op, it, _, code;
+    var that, op, it, _$, code;
     if (that = this.compileSpread(o)) {
       return that;
     }
@@ -1403,10 +1401,11 @@ exports.Unary = Unary = (function(superclass){
       it.isCallable() || it.carp('invalid constructor');
       break;
     case 'do':
-      _ = Parens(it instanceof Existence && !it.negated
+      _$ = Parens(it instanceof Existence && !it.negated
         ? Chain(it).add(Call())
         : Call.make(it));
-      return (_.front = this.front, _.newed = this.newed, _).compile(o);
+return (_$.front = this.front, _$.newed = this.newed, _$).compile(o);;
+      break;
     case 'delete':
       if (it instanceof Var || !it.isAssignable()) {
         this.carp('invalid delete');
@@ -1627,17 +1626,16 @@ exports.Binary = Binary = (function(superclass){
     }
   };
   prototype.compileExistence = function(o){
-    var _, ref$;
+    var _$, ref$;
     if (this.op === '!?') {
-      _ = (ref$ = If(Existence(this.first), this.second), ref$.cond = this.cond, ref$['void'] = this['void'] || !o.level, ref$);
-      return _.compileExpression(o);
+      _$ = (ref$ = If(Existence(this.first), this.second), ref$.cond = this.cond, ref$['void'] = this['void'] || !o.level, ref$);
+return _$.compileExpression(o);;
     }
     if (this['void'] || !o.level) {
-      _ = Binary('&&', Existence(this.first, true), this.second);
-      return (_['void'] = true, _).compileNode(o);
+      _$ = Binary('&&', Existence(this.first, true), this.second);
+return (_$['void'] = true, _$).compileNode(o);;
     }
-    _ = this.first.cache(o, true);
-    return If(Existence(_[0]), _[1]).addElse(this.second).compileExpression(o);
+    return (_$ = this.first.cache(o, true), If(Existence(_$[0]), _$[1]).addElse(this.second).compileExpression(o));
   };
   prototype.compileAnyInstanceOf = function(o, items){
     var ref$, sub, ref, test, i$, len$, item;
@@ -1650,11 +1648,10 @@ exports.Binary = Binary = (function(superclass){
     return Parens(test).compile(o);
   };
   prototype.compileMinMax = function(o){
-    var lefts, rites, _;
+    var lefts, rites, _$;
     lefts = this.first.cache(o, true);
     rites = this.second.cache(o, true);
-    _ = Binary(this.op.charAt(), lefts[0], rites[0]);
-    return If(_, lefts[1]).addElse(rites[1]).compileExpression(o);
+    return (_$ = Binary(this.op.charAt(), lefts[0], rites[0]), If(_$, lefts[1]).addElse(rites[1]).compileExpression(o));
   };
   prototype.compileMethod = function(o, klass, method, arg){
     var args;
@@ -3125,6 +3122,33 @@ exports.Label = Label = (function(superclass){
       : it.compile(o));
   };
   return Label;
+}(Node));
+exports.Pipe = Pipe = (function(superclass){
+  Pipe.displayName = 'Pipe';
+  var prototype = extend$(Pipe, superclass).prototype, constructor = Pipe;
+  function Pipe(left, right){
+    var this$ = this instanceof ctor$ ? this : new ctor$;
+    this$.left = left;
+    this$.right = right;
+    return this$;
+  } function ctor$(){} ctor$.prototype = prototype;
+  prototype.compileNode = function(o){
+    var firstPipe, t, right, code, ref$;
+    firstPipe = o.pipee == null;
+    if (firstPipe) {
+      o.pipee = o.scope.temporary('_');
+    }
+    t = o.pipee + ' = ' + this.left.compile(o, LEVEL_LIST);
+    right = this.right.compile(o);
+    code = o.level
+      ? "(" + t + ", " + right + ")"
+      : t + ";\n" + right;
+    if (firstPipe) {
+      o.scope.free((ref$ = o.pipee, delete o.pipee, ref$));
+    }
+    return code;
+  };
+  return Pipe;
 }(Node));
 exports.Cascade = Cascade = (function(superclass){
   Cascade.displayName = 'Cascade';

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -121,7 +121,7 @@ bnf = {
         ? Binary($2.slice(1), $1, $3).invert()
         : Binary($2, $1, $3);
     }), o('Expression |> Expression', function(){
-      return Block($1).pipe($3);
+      return Pipe($1, $3);
     }), o('Chain !?', function(){
       return Existence($1.unwrap(), true);
     }), o('PARAM( ArgList OptComma )PARAM -> Block', function(){

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -104,7 +104,7 @@ case 61:this.$ = '!' === $$[$0-1].charAt(0)
         ? yy.Binary($$[$0-1].slice(1), $$[$0-2], $$[$0]).invert()
         : yy.Binary($$[$0-1], $$[$0-2], $$[$0]);
 break;
-case 62:this.$ = yy.Block($$[$0-2]).pipe($$[$0]);
+case 62:this.$ = yy.Pipe($$[$0-2], $$[$0]);
 break;
 case 63:this.$ = yy.Existence($$[$0-1].unwrap(), true);
 break;

--- a/src/ast.co
+++ b/src/ast.co
@@ -214,8 +214,6 @@ class exports.Block extends Node
     @lines.splice @neck!, 0, ...arguments
     this
 
-  pipe: -> @lines.push Assign(Var \_; @lines.pop!), it; this
-
   unwrap: -> if @lines.length is 1 then @lines.0 else this
 
   # Removes trailing comment nodes.
@@ -341,7 +339,9 @@ class exports.Var extends Atom
 
   varName: ::show
 
-  compile: (o) -> if @temp then o.scope.free @value else @value
+  compile: (o) ->
+    @value = o.pipee if o.pipee? and @value is \_ # don't clobber _ within pipes
+    if @temp then o.scope.free @value else @value
 
 #### Key
 # A property name in the form of `{key: _}` or `_.key`.
@@ -1911,6 +1911,24 @@ class exports.Label extends Node
     "#label: " + if it instanceof Block
       then o.indent += TAB; @compileBlock o, it
       else it.compile o
+
+#### Pipe
+# A construction that binds the result of the left-hand expression to _ for the
+# right-hand expression, and results in the right-hand expression
+class exports.Pipe extends Node
+  (@left, @right) ~>
+
+  compileNode: (o) ->
+    first-pipe = o.pipee!?
+    o.pipee = o.scope.temporary \_ if first-pipe
+
+    t = o.pipee + ' = ' + @left.compile o, LEVEL_LIST
+    right = @right.compile o
+    code = if o.level then "(#t, #right)" else "#t;\n#right"
+
+    o.scope.free delete o.pipee if first-pipe
+
+    code
 
 #### Cascade
 # A construction that allows `&`-references to target expression.

--- a/src/grammar.co
+++ b/src/grammar.co
@@ -168,7 +168,7 @@ bnf =
       *if \! is $2.charAt 0 then Binary $2.slice(1), $1, $3 .invert!
                             else Binary $2         , $1, $3
 
-    o 'Expression |> Expression' -> Block $1 .pipe $3
+    o 'Expression |> Expression' -> Pipe $1, $3
 
     o 'Chain !?' -> Existence $1.unwrap!, true
 

--- a/test/operator.co
+++ b/test/operator.co
@@ -429,6 +429,9 @@ String 0
 eq void,
   -> |> _ _ |> _
 
+_ = \unclobbered
+\clobbered |> _.toUpperCase! |> _.toLowerCase!
+eq \unclobbered _
 
 ### Listar
 * 0, 1


### PR DESCRIPTION
...Is the end goal here, but I have questions on the approach, if you're willing to help. 

The relevant code appears to be:

grammar.co:

``` coco
    o 'Expression |> Expression' -> Block $1 .pipe $3
```

ast.co:

``` coco
  pipe: -> @lines.push Assign(Var \_; @lines.pop!), it; this
```

I also found `scope#temporary` for getting a new name, but I'm unsure how to change the `_` variable within the right-hand side of the pipe to the temporary binding. Is the implementation of pipe as just the `Node#pipe` method sufficient to do this, or would it be better to make `Pipe extends Node` to hold the logic for this?
