### PR TITLE
End stdin on ctrl+d

### DIFF
--- a/Cokefile
+++ b/Cokefile
@@ -10,7 +10,7 @@ tint = (text, color ? green) -> color + text + reset
 
 # Run our node/coco interpreter.
 run = (args) ->
-  proc = spawn \node [\bin/coco]concat args
+  proc = spawn \node [\lib/command]concat args
   proc.stderr.on \data say
   proc       .on \exit -> process.exit it if it
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -226,7 +226,13 @@ function compileStdin(){
   x0$ = process.openStdin();
   code = '';
   x0$.on('data', function(it){
-    code += it;
+    var ref$;
+    if (4 === (ref$ = it.toString().trim())[ref$.length - 1].charCodeAt() || 4 === it.toString().charCodeAt()) {
+      compileScript('', code);
+      process.exit();
+    } else {
+      code += it;
+    }
   });
   x0$.on('end', function(){
     compileScript('', code);

--- a/src/command.co
+++ b/src/command.co
@@ -150,12 +150,12 @@ default
 # Attach the appropriate listeners to compile scripts incoming over **stdin**.
 !function compileStdin
   argv.1 = \stdin
-  stdin = process.openStdin!
+  process.openStdin!
     code = ''
     &on \data !->
-      if it.toString!charCodeAt! is 4 # ctrl-Z
-        stdin.resume!
+      if 4 of [it.toString!trim![*-1]charCodeAt!, it.toString!charCodeAt!] # ctrl-D
         compileScript '' code
+        process.exit!
       else
         code += it
     &on \end  !-> compileScript '' code

--- a/src/command.co
+++ b/src/command.co
@@ -150,9 +150,14 @@ default
 # Attach the appropriate listeners to compile scripts incoming over **stdin**.
 !function compileStdin
   argv.1 = \stdin
-  process.openStdin!
+  stdin = process.openStdin!
     code = ''
-    &on \data !-> code += it
+    &on \data !->
+      if it.toString!charCodeAt! is 4 # ctrl-Z
+        stdin.resume!
+        compileScript '' code
+      else
+        code += it
     &on \end  !-> compileScript '' code
 
 # Watch a source Coco file using `setTimeout`, taking an `action` every


### PR DESCRIPTION
Looks like Windows can't generate EOF, which prevents using `coco -s`
- Should it be CTRL+D to be on par with unix ?
- Should it be CTRL+Z because [Wiki said it was the code used back then](http://en.wikipedia.org/wiki/End-of-file)
- maybe another way to track that ? this requires a CR currently.
- do you not want that
